### PR TITLE
Make `change_account` method async to support proper await usage

### DIFF
--- a/pyquotex/stable_api.py
+++ b/pyquotex/stable_api.py
@@ -254,7 +254,7 @@ class Quotex:
             logger.error("ERROR doesn't have this mode")
             exit(1)
 
-    def change_account(self, balance_mode: str):
+    async def change_account(self, balance_mode: str):
         """Change active account `real` or `practice`"""
         self.account_is_demo = 0 if balance_mode.upper() == "REAL" else 1
         self.api.change_account(self.account_is_demo)


### PR DESCRIPTION
Refactored the `change_account` method in the Quotex client to be asynchronous (`async def`)  in order to support proper usage with `await` across the codebase.

Previously, this method was synchronous, which caused a TypeError ("NoneType can't be used in 'await' expression") when `await self.client.change_account(...)` was called. Since `self.api.change_account(...)`  involves asynchronous behavior (likely network I/O over websockets), this method should have  been async from the beginning.

This change ensures safe, consistent async handling for account switching operations throughout the application.

<img width="2788" height="1429" alt="image" src="https://github.com/user-attachments/assets/5b841898-f9fc-49d8-a27c-73c1a01c6f5b" />
