### PR TITLE
suppress: disable realtime candle print in pyquotex client.py

### DIFF
--- a/pyquotex/ws/client.py
+++ b/pyquotex/ws/client.py
@@ -142,7 +142,7 @@ class WebsocketClient(object):
                 }
                 self.api.realtime_price[message[0][0]].append(result)
                 self.api.realtime_candles[self.api.current_asset] = message[0]
-                print(self.api.realtime_candles)
+                #print(self.api.realtime_candles)
             elif len(message[0]) == 2:
                 for i in message:
                     result = {


### PR DESCRIPTION
Commented out `print(self.api.realtime_candles)` inside pyquotex's client.py to suppress repeated logging of candle updates during active trades.

This was causing excessive console noise such as:
{'EURCHF_otc': ['EURCHF_otc', 1752551343.125, 0.95585, 0]}

The countdown and trading feedback remain functional. This change helps declutter the terminal and improves readability during live sessions.