### PR TITLE
fix(stable_api): correct poll-loop bugs in get_history_line and get_candle_v2

### DIFF
--- a/pyquotex/stable_api.py
+++ b/pyquotex/stable_api.py
@@ -486,32 +486,23 @@ class Quotex:
 
         index = expiration.get_timestamp()
         self.api.current_asset = asset
-        self.api.historical_candles = {}
+        # Reset to None (not {}) so the poll loop below can detect arrival.
+        # An empty dict is a valid response; None is the sentinel for
+        # "not yet received".
+        self.api.historical_candles = None
         await self.start_candles_stream(asset)
         await self.api.get_history_line(
             self.codes_asset[asset], index, end_from_time, offset
         )
         start_time = time.time()
-        while True:
-            while (
-                    await self.check_connect()
-                    and self.api.historical_candles is None
-            ):
-                if time.time() - start_time > timeout:
-                    logger.error(
-                        "Timeout waiting for history line data for %s.",
-                        asset
-                    )
-                    return None
-                await asyncio.sleep(0.2)
-            if self.api.historical_candles is not None:
-                break
+        while await self.check_connect() and self.api.historical_candles is None:
             if time.time() - start_time > timeout:
                 logger.error(
                     "Timeout waiting for history line data for %s.",
                     asset
                 )
                 return None
+            await asyncio.sleep(0.2)
         return self.api.historical_candles
 
     async def get_candle_v2(
@@ -524,13 +515,18 @@ class Quotex:
         self.api.candle_v2_data[asset] = None
         await self.start_candles_stream(asset, period)
         start_time = time.time()
+        # Poll until data arrives or timeout is reached.
+        # Previous code returned None on every iteration because the
+        # return statement was inside the while-body instead of the
+        # timeout branch, so data was never awaited.
         while self.api.candle_v2_data[asset] is None:
-            logger.error(
-                "Timeout waiting for get_candle_v2 data for %s.",
-                asset
-            )
-            return None
-        await asyncio.sleep(0.2)
+            if time.time() - start_time > timeout:
+                logger.error(
+                    "Timeout waiting for get_candle_v2 data for %s.",
+                    asset
+                )
+                return None
+            await asyncio.sleep(0.2)
         candles = self.prepare_candles(asset, period)
         return candles
 


### PR DESCRIPTION
## Problems Fixed

### 1. `get_history_line` — wrong sentinel causes immediate empty return (closes #78)

`historical_candles` was reset to `{}` (empty dict) before the request, but the poll loop checked `is None`:

```python
# Before (broken)
self.api.historical_candles = {}   # sentinel is empty dict
while (
    await self.check_connect()
    and self.api.historical_candles is None   # ← always False on first check
):
    ...  # loop body never entered
# Returns {} immediately — before WS data arrives
```

Because `{} is None` is `False`, the inner loop body never ran. The method returned an empty dict before any WebSocket response was received. Reported in #78 — the community workaround confirmed the async polling was never executing.

**Fix:** use `None` as the sentinel (not `{}`). An empty dict is a valid broker response; `None` is the unambiguous "not yet received" state.

---

### 2. `get_candle_v2` — `return None` inside while body, never polls

```python
# Before (broken)
while self.api.candle_v2_data[asset] is None:
    logger.error("Timeout...")
    return None   # ← fires on first iteration unconditionally
await asyncio.sleep(0.2)   # unreachable
```

The `return None` was the only statement in the loop body, so the method always exited on the first iteration. Data was never awaited.

**Fix:** move the early-return inside a proper timeout check and add `asyncio.sleep(0.2)` to yield the event loop between polls.

---

## Changes

| File | Change |
|---|---|
| `pyquotex/stable_api.py` | Fix sentinel in `get_history_line` (`{}` → `None`) and restructure poll loop in `get_candle_v2` |

Only `stable_api.py` is touched. One file, two surgical fixes.

---

## Verification

- 22 unit tests pass (`pytest tests/test_expiration.py tests/test_indicators.py tests/test_processor.py tests/test_account_type.py`)
- Logic verified with async simulation: both methods now correctly poll until WS data arrives and respect the `timeout` parameter
- No public API surface changed — drop-in fix